### PR TITLE
DSU and NVMCTRL fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,8 +49,8 @@ target_sources(samd21-hal-sources INTERFACE
 )
 
 add_library(samd21-hal-options INTERFACE)
-target_compile_options(samd21-hal-options INTERFACE "-mcpu=cortex-m0" "-gdwarf-2" "-mthumb")
-target_link_options(samd21-hal-options INTERFACE "-mcpu=cortex-m0" "-mthumb")
+target_compile_options(samd21-hal-options INTERFACE "-mcpu=cortex-m0plus" "-gdwarf-2" "-mthumb")
+target_link_options(samd21-hal-options INTERFACE "-mcpu=cortex-m0plus" "-mthumb")
 target_link_directories(samd21-hal-options INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/ld)
 
 if(SAMD21_HAL_BUILD_TESTS)
@@ -66,8 +66,8 @@ if(SAMD21_HAL_BUILD_TESTS)
         tests/main.c
     )
     target_link_libraries(samd21-hal-test PRIVATE samd21-hal-test-lib)
-    target_compile_options(samd21-hal-test PRIVATE "-mcpu=cortex-m0" "-gdwarf-2" "-mthumb")
-    target_link_options(samd21-hal-test PRIVATE "-mcpu=cortex-m0" "-mthumb")
+    target_compile_options(samd21-hal-test PRIVATE "-mcpu=cortex-m0plus" "-gdwarf-2" "-mthumb")
+    target_link_options(samd21-hal-test PRIVATE "-mcpu=cortex-m0plus" "-mthumb")
     target_link_options(samd21-hal-test PRIVATE -TATSAMD21E18A.ld)
     target_link_options(samd21-hal-test PRIVATE -Wl,-Map=samd21-test.map -Wl,--gc-sections)
     set_target_properties(samd21-hal-test PROPERTIES SUFFIX ".elf")

--- a/include/hal/nvmctrl.h
+++ b/include/hal/nvmctrl.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-void NVMCTRL_EraseRow(uint16_t row);
+void NVMCTRL_EraseRow(uint32_t address);
 
 void NVMCTRL_PageBufferClear(void);
 

--- a/src/hal/dsu.c
+++ b/src/hal/dsu.c
@@ -9,6 +9,7 @@ uint32_t DSU_CalculateCRC32(uint32_t initial, void* start, uint32_t length) {
     DSU_REGS->DSU_ADDR = DSU_ADDR_ADDR(((uint32_t) start) >> 2);
     DSU_REGS->DSU_LENGTH = DSU_LENGTH_LENGTH(length / 4);
     DSU_REGS->DSU_DATA = initial;
+    DSU_REGS->DSU_STATUSA |= (DSU_STATUSA_DONE_Msk);
     DSU_REGS->DSU_CTRL |= (DSU_CTRL_CRC_Msk);
 
     while ((DSU_REGS->DSU_STATUSA & DSU_STATUSA_DONE_Msk) == 0);

--- a/src/hal/nvmctrl.c
+++ b/src/hal/nvmctrl.c
@@ -2,8 +2,8 @@
 
 #include "atsamd21e18a.h"
 
-void NVMCTRL_EraseRow(uint16_t row) {
-    NVMCTRL_REGS->NVMCTRL_ADDR = (row * 128UL * 4UL) / 2;
+void NVMCTRL_EraseRow(uint32_t address) {
+    NVMCTRL_REGS->NVMCTRL_ADDR = address >> 1U;
     NVMCTRL_REGS->NVMCTRL_CTRLA = NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_ER;
 
     while ((NVMCTRL_REGS->NVMCTRL_INTFLAG & NVMCTRL_INTFLAG_READY_Msk) == 0);
@@ -15,7 +15,7 @@ void NVMCTRL_PageBufferClear(void) {
 }
 
 void NVMCTRL_WritePage(uint32_t address) {
-    NVMCTRL_REGS->NVMCTRL_ADDR = address / 2;
+    NVMCTRL_REGS->NVMCTRL_ADDR = address >> 1U;
     NVMCTRL_REGS->NVMCTRL_CTRLA = NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_WP;
     while ((NVMCTRL_REGS->NVMCTRL_INTFLAG & NVMCTRL_INTFLAG_READY_Msk) == 0);
 }
@@ -35,9 +35,9 @@ void NVMCTRL_SetReadWaitStates(uint8_t wait_states) {
 }
 
 uint16_t NVMCTRL_GetPageSize(void) {
-    return (1 << (3 + (NVMCTRL_REGS->NVMCTRL_PARAM & NVMCTRL_PARAM_PSZ_Msk >> NVMCTRL_PARAM_PSZ_Pos)));
+    return (1U << (3U + ((NVMCTRL_REGS->NVMCTRL_PARAM & NVMCTRL_PARAM_PSZ_Msk) >> NVMCTRL_PARAM_PSZ_Pos)));
 }
 
 uint16_t NVMCTRL_GetPageCount(void) {
-    return NVMCTRL_REGS->NVMCTRL_PARAM & NVMCTRL_PARAM_NVMP_Msk >> NVMCTRL_PARAM_NVMP_Pos;
+    return (NVMCTRL_REGS->NVMCTRL_PARAM & NVMCTRL_PARAM_NVMP_Msk) >> NVMCTRL_PARAM_NVMP_Pos;
 }


### PR DESCRIPTION
## Brief

- Fixes CPU compilation flags
- NVMCTRL_EraseRow now takes the address instead
- DSU Ready flag is cleared before CRC calculation is started
- Fixes Page size and Page count functions